### PR TITLE
chore: update hyperref settings

### DIFF
--- a/sjtuthesis/source/sjtuthesis.dtx
+++ b/sjtuthesis/source/sjtuthesis.dtx
@@ -1846,6 +1846,18 @@
 %    \begin{macrocode}
 \ctex_at_end_package:nn { hyperref }
   {
+    \hypersetup
+      {
+        linktoc            = all,
+        bookmarksdepth     = 2,
+        bookmarksnumbered  = true,
+        bookmarksopen      = true,
+        bookmarksopenlevel = 1,
+        unicode            = true,
+        psdextra           = true,
+        breaklinks         = true,
+        pdfdisplaydoctitle = true
+      }
     \int_new:N \g_@@_bookmark_int
     \cs_gset_protected:Npn \@@_pdf_bookmark:nn #1#2
       {
@@ -1862,30 +1874,15 @@
         \cs_set_eq:NN \qquad   \c_empty_tl
         \cs_set_eq:NN \hspace  \use_none:n
       }
-    \ctex_at_end_package:nn { hyperref }
-      {
-        \hypersetup{
-          linktoc            = all,
-          bookmarksdepth     = 2,
-          bookmarksnumbered  = true,
-          bookmarksopen      = true,
-          bookmarksopenlevel = 1,
-          unicode            = true,
-          psdextra           = true,
-          breaklinks         = true,
-          plainpages         = false,
-          pdfdisplaydoctitle = true,
-          hidelinks,
-        }
-      }
     \ctex_after_end_preamble:n
       {
-        \hypersetup{
-          pdftitle    = \l_@@_info_title_zh_tl ,
-          pdfsubject  = \c_@@_name_subject_full_zh_tl ,
-          pdfkeywords = \l_@@_info_keywords_zh_clist ,
-          pdfauthor   = \l_@@_info_author_zh_tl
-        }
+        \hypersetup
+          {
+            pdftitle    = \l_@@_info_title_zh_tl,
+            pdfsubject  = \c_@@_name_subject_full_zh_tl,
+            pdfkeywords = \l_@@_info_keywords_zh_clist,
+            pdfauthor   = \l_@@_info_author_zh_tl
+          }
       }
   }
 %    \end{macrocode}

--- a/sjtuthesis/source/sjtuthesis.dtx
+++ b/sjtuthesis/source/sjtuthesis.dtx
@@ -1862,6 +1862,22 @@
         \cs_set_eq:NN \qquad   \c_empty_tl
         \cs_set_eq:NN \hspace  \use_none:n
       }
+    \ctex_at_end_package:nn { hyperref }
+      {
+        \hypersetup{
+          linktoc            = all,
+          bookmarksdepth     = 2,
+          bookmarksnumbered  = true,
+          bookmarksopen      = true,
+          bookmarksopenlevel = 1,
+          unicode            = true,
+          psdextra           = true,
+          breaklinks         = true,
+          plainpages         = false,
+          pdfdisplaydoctitle = true,
+          hidelinks,
+        }
+      }
     \ctex_after_end_preamble:n
       {
         \hypersetup{


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

把 v1 的 hyperref 设置原样拷过来，现在文档中的链接不会有红色方框。