### PR TITLE
feat: add support for `minted` package

### DIFF
--- a/sjtutex/source/sjtutex.dtx
+++ b/sjtutex/source/sjtutex.dtx
@@ -1179,7 +1179,7 @@
 %
 % \begin{function}[updated=2023-03-18]{name/contents,name/listfigure,name/listtable,
 %   name/figure,name/table,name/abstract,name/index,name/appendix,name/proof,name/bib,
-%   name/figure*,name/table*,name/algorithm,name/listalgorithm,
+%   name/figure*,name/table*,name/listing,name/listing*,name/algorithm,name/listalgorithm,
 %   name/abbr,name/nom,name/ack,name/resume,name/digest,name/achv}
 % \end{function}
 %
@@ -1217,6 +1217,7 @@
 %     |table*|             & Table                  & 表                            & Table                  & Table                \\
 %     |algorithm|          & 算法                   & Algorithm                     & Algorithmus            & アルゴリズム         \\
 %     |listalgorithm|      & 算法                   & List of Algorithms            & Algorithmenverzeichnis & アルゴリズム目次     \\
+%     |listing|            & 代码清单                & Listing                       & Liste der Codes       & コードリスト          \\
 %     |abbr| \rexpstar     & 缩略语对照表           & Abbreviation                  & Abkürzungsverzeichnis  & 略語表               \\
 %     |nom| \rexpstar      & 主要符号对照表         & Nomenclature                  & Symbolverzeichnis      & 記号表               \\
 %     |ack| \rexpstar      & 致谢                   & Acknowledgements              & Danksagungen           & 謝辞                 \\
@@ -3187,6 +3188,10 @@
     figure*       .initial:n = { 图 } ,
     table*         .tl_set:N = \SJTU@tablename@aux ,
     table*        .initial:n = { 表 } ,
+    listing        .tl_set:N = \SJTU@listingname ,
+    listing       .initial:n = { Listing } ,
+    listing*       .tl_set:N = \SJTU@listingname@aux ,
+    listing*      .initial:n = { 代码清单 } ,
     algorithm      .tl_set:N = \SJTU@algorithmname ,
     algorithm     .initial:n = { Algorithm } ,
     listalgorithm  .tl_set:N = \SJTU@listalgorithmname ,
@@ -3219,6 +3224,7 @@
     listtable     = { 表 \quad 格 } ,
     figure        = { 图 } ,
     table         = { 表 } ,
+    listing       = { 代码清单 } ,
     abstract      = { 摘 \quad 要 } ,
     index         = { 索 \quad 引 } ,
     appendix      = { 附录 } ,
@@ -3258,6 +3264,7 @@
     table*        = { Table } ,
     algorithm     = { Algorithmus } ,
     listalgorithm = { Algorithmenverzeichnis } ,
+    listing       = { Liste der Codes } ,
     abbr          = { Abkürzungsverzeichnis } ,
     nom           = { Symbolverzeichnis } ,
     ack           = { Danksagungen } ,
@@ -3286,6 +3293,7 @@
     table*        = { Table } ,
     algorithm     = { アルゴリズム } ,
     listalgorithm = { アルゴリズム目次 } ,
+    listing       = { コードリスト } ,
     abbr          = { 略語表 } ,
     nom           = { 記号表 } ,
     ack           = { 謝 \quad 辞 } ,
@@ -5245,29 +5253,23 @@
   }
 %    \end{macrocode}
 %
+% \subsubsection{\pkg{nomencl} 宏包}
+%    \begin{macrocode}
+\ctex_at_end_package:nn { nomencl }
+  { \tl_set:Nn \nomname { \SJTU@nomname } }
+%    \end{macrocode}
+%
 % \subsubsection{\pkg{minted} 宏包}
 %    \begin{macrocode}
 \ctex_at_end_package:nn { minted }
   {
-    % Define names
-    \keys_define:nn { sjtu / name }
-      {
-        listing   .tl_set:N = \l__sjtu_name_listing_tl ,
-        listing  .initial:n = { Listing } ,
-        listing*  .tl_set:N = \l__sjtu_name_listing_aux_tl ,
-        listing* .initial:n = { 代码清单 } ,
-      }
-    % Set caption name
-    \captionsetup [ listing ] { name = \l__sjtu_name_listing_aux_tl }
-    \captionsetup [ listing ] [ bi-first  ] { name = \l__sjtu_name_listing_aux_tl }
-    \captionsetup [ listing ] [ bi-second ] { name = \l__sjtu_name_listing_tl     }
-    % Set numbering style
-    \AtBeginDocument
-      {
-        \cs_set:Npn \thelisting
-          { \thechapter \l__sjtu_style_fl_num_sep_tl \arabic { listing } }
-      }
-    % Set display style
+    \captionsetup [ listing ] { name = \SJTU@listingname }
+    \captionsetup [ listing ] [ bi-first  ] { name = \SJTU@listingname     }
+    \captionsetup [ listing ] [ bi-second ] { name = \SJTU@listingname@aux }
+
+    \cs_set:Npn \thelisting
+      { \thechapter \l__sjtu_style_fl_num_sep_tl \arabic { listing } }
+
     \setminted
       {
         frame           = lines ,
@@ -5279,18 +5281,10 @@
         stripnl ,
         tabsize         = 4
       }
-    % Remove redundant vertical space around listings
-    \let \oldminted    \minted
-    \let \oldendminted \endminted
-    \def \minted    { \vspace { -0.4cm } \oldminted }
-    \def \endminted { \oldendminted \vspace { -0.4cm } }
+
+    \@@_preto_cmd:Nn \minted    { \vspace { -0.4cm } }
+    \@@_appto_cmd:Nn \endminted { \vspace { -0.4cm } }
   }
-%    \end{macrocode}
-%
-% \subsubsection{\pkg{nomencl} 宏包}
-%    \begin{macrocode}
-\ctex_at_end_package:nn { nomencl }
-  { \tl_set:Nn \nomname { \SJTU@nomname } }
 %    \end{macrocode}
 %
 %    \begin{macrocode}

--- a/sjtutex/source/sjtutex.dtx
+++ b/sjtutex/source/sjtutex.dtx
@@ -5282,8 +5282,13 @@
         tabsize         = 4
       }
 
-    \@@_preto_cmd:Nn \minted    { \vspace { -0.4cm } }
-    \@@_appto_cmd:Nn \endminted { \vspace { -0.4cm } }
+    \makeatletter
+    \newenvironment{code}{%
+      \VerbatimEnvironment
+      \let\FV@ListVSpace\relax
+      \begin{minted}}%
+    {\end{minted}}
+    \makeatother
   }
 %    \end{macrocode}
 %

--- a/sjtutex/source/sjtutex.dtx
+++ b/sjtutex/source/sjtutex.dtx
@@ -919,8 +919,9 @@
 %   \begin{sjtusyntax}
 %     (*\meta{lang}*)/subject = (*\marg{主题}*)
 %   \end{sjtusyntax}
-%   文档主题。一般显示在中文标题页校徽下方。默认值类似于“上海交通大学学士学位论文” 或
-%   “A Dissertation Submitted to Shanghai Jiao Tong University for Bachelor Degree”。
+%   文档主题。一般显示在中文标题页校徽下方。
+%   默认值类似于 “上海交通大学学士学位论文” 或 “A Dissertation Submitted to
+%   Shanghai Jiao Tong University for the Degree of Bachelor”。
 % \end{function}
 %
 % \begin{function}[rEXP,updated=2023-03-14]{info/<lang>/keywords}
@@ -3948,6 +3949,7 @@
 %
 % \subsection{多语言支持}
 %
+% \changes{unreleased}{2023/04/02}{更新学位论文初始英文主题。}
 % 初始化主题。
 %    \begin{macrocode}
 %<*lang>
@@ -3967,7 +3969,7 @@
 %<*en>
         A~ Dissertation~ Submitted~ to \exp_not:N \\
         { \exp_not:V \c_@@_name_univ_en_tl }~ for~
-        { \exp_not:V \c_@@_name_degree_level_en_tl }~ Degree
+        the~ Degree~ of~ { \exp_not:V \c_@@_name_degree_level_en_tl }
 %</en>
 %<*de>
         Eine~ Dissertation~ Eingereicht~ an \exp_not:N \\

--- a/sjtutex/source/sjtutex.dtx
+++ b/sjtutex/source/sjtutex.dtx
@@ -1921,6 +1921,7 @@
     { amsmath, thmmarks } { ntheorem     } ,
 %<!article>    { chapter           } { algorithm    } ,
 %<!article>    { algochapter       } { algorithm2e  } ,
+    { chapter, newfloat } { minted       } ,
     {
       \bool_if:NTF \g_@@_integral_limits_bool
         { displaylimits } { nolimits }
@@ -5241,6 +5242,48 @@
         texcl             = true ,
         mathescape        = true
       }
+  }
+%    \end{macrocode}
+%
+% \subsubsection{\pkg{minted} 宏包}
+%    \begin{macrocode}
+\ctex_at_end_package:nn { minted }
+  {
+    % Define names
+    \keys_define:nn { sjtu / name }
+      {
+        listing   .tl_set:N = \l__sjtu_name_listing_tl ,
+        listing  .initial:n = { Listing } ,
+        listing*  .tl_set:N = \l__sjtu_name_listing_aux_tl ,
+        listing* .initial:n = { 代码清单 } ,
+      }
+    % Set caption name
+    \captionsetup [ listing ] { name = \l__sjtu_name_listing_aux_tl }
+    \captionsetup [ listing ] [ bi-first  ] { name = \l__sjtu_name_listing_aux_tl }
+    \captionsetup [ listing ] [ bi-second ] { name = \l__sjtu_name_listing_tl     }
+    % Set numbering style
+    \AtBeginDocument
+      {
+        \cs_set:Npn \thelisting
+          { \thechapter \l__sjtu_style_fl_num_sep_tl \arabic { listing } }
+      }
+    % Set display style
+    \setminted
+      {
+        frame           = lines ,
+        framerule       = 1pt ,
+        framesep        = 3mm ,
+        autogobble ,
+        baselinestretch = 1 ,
+        breaklines ,
+        stripnl ,
+        tabsize         = 4
+      }
+    % Remove redundant vertical space around listings
+    \let \oldminted    \minted
+    \let \oldendminted \endminted
+    \def \minted    { \vspace { -0.4cm } \oldminted }
+    \def \endminted { \oldendminted \vspace { -0.4cm } }
   }
 %    \end{macrocode}
 %


### PR DESCRIPTION
之前提了 <https://github.com/sjtug/SJTUThesis/pull/859>，不过当时建议等 v2 重构之后再提，看起来现在可以提了（

给 `minted` 宏包添加了默认 options 和 `ctex_at_end_package` 脚本，主要包括设置 float 对象名、编号行为、显示样式。

例子（<https://github.com/richardchien/SJTUThesis/tree/rc/support-minted-example>）：

```tex
\begin{listing}[!hpt]
  \bicaption{代码示例}{Code Example}
  \label{code:codelisting}
  \begin{minted}{python}
    def hello():
        foo = bar()
  \end{minted}
\end{listing}
```

<img width="761" alt="image" src="https://user-images.githubusercontent.com/5317095/222430429-627b5cb3-89eb-4199-b765-e4585782246e.png">
