### PR TITLE
V2 Adjust LoFTA style

### DIFF
--- a/sjtutex/source/sjtutex.dtx
+++ b/sjtutex/source/sjtutex.dtx
@@ -4734,13 +4734,16 @@
 %    \end{macrocode}
 %
 % \changes{v2.0.1}{2023/03/31}{修正表格索引编号宽度。}
+% \changes{v2.0.1}{2023/03/31}{插图、表格和算法等索引不缩进。}
 % 图表清单标题前添加名称。
 %    \begin{macrocode}
 \cs_new_protected:Nn \@@_update_cft_presnum:
   {
     \tl_set:Nn \cftfigpresnum { \figurename \c_space_tl }
+    \dim_zero:N \cftfigindent
     \@@_dim_add_to_wd:Nn \cftfignumwidth { \cftfigpresnum }
     \tl_set:Nn \cfttabpresnum { \tablename  \c_space_tl }
+    \dim_zero:N \cfttabindent
     \@@_dim_add_to_wd:Nn \cfttabnumwidth { \cfttabpresnum }
   }
 \ctex_at_end_preamble:n
@@ -5153,7 +5156,7 @@
     \exp_args:Nnv \newlistentry {#2} { ext@ #3 } { 0 }
     \exp_args:Ne \newcounter { \tl_use:c { ext@ #3 } depth }
     \exp_args:Ne \setcounter { \tl_use:c { ext@ #3 } depth } { 1 }
-    \dim_set:cn { cft #2 indent   } { 1.5 em }
+    \dim_zero:c { cft #2 indent   }
     \dim_set:cn { cft #2 numwidth } { 2.3 em }
     \cs_set_eq:cc { l@ #3 } { l@ #2 }
     \@@_appto_cmd:Nn \@@_update_cft_presnum:

--- a/sjtutex/source/sjtutex.dtx
+++ b/sjtutex/source/sjtutex.dtx
@@ -3297,7 +3297,7 @@
   { title_page, declaration, abstract }
   { \@@_define_name:nv {#1} { c_@@_name_ #1 _ \g_@@_lang_tl _tl } }
 %</thesis>
-%<!thesis> \file_input:n { sjtu-name-generic- \g_@@_lang_tl .def }
+%<!thesis>\file_input:n { sjtu-name-generic- \g_@@_lang_tl .def }
 %    \end{macrocode}
 %
 % \subsection{页面布局}
@@ -4733,6 +4733,7 @@
 %<!article>\tl_set:Nn \cftchapleader { \normalfont \cftdotfill { \cftdotsep } }
 %    \end{macrocode}
 %
+% \changes{v2.0.1}{2023/03/31}{修正表格索引编号宽度。}
 % 图表清单标题前添加名称。
 %    \begin{macrocode}
 \cs_new_protected:Nn \@@_update_cft_presnum:
@@ -4740,7 +4741,7 @@
     \tl_set:Nn \cftfigpresnum { \figurename \c_space_tl }
     \@@_dim_add_to_wd:Nn \cftfignumwidth { \cftfigpresnum }
     \tl_set:Nn \cfttabpresnum { \tablename  \c_space_tl }
-    \@@_dim_add_to_wd:Nn \cfttabnumwidth { \cftfigpresnum }
+    \@@_dim_add_to_wd:Nn \cfttabnumwidth { \cfttabpresnum }
   }
 \ctex_at_end_preamble:n
   { \@@_update_cft_presnum: }

--- a/sjtutex/source/sjtutex.dtx
+++ b/sjtutex/source/sjtutex.dtx
@@ -4733,17 +4733,21 @@
 %<!article>\tl_set:Nn \cftchapleader { \normalfont \cftdotfill { \cftdotsep } }
 %    \end{macrocode}
 %
-% \changes{v2.0.1}{2023/03/31}{修正表格索引编号宽度。}
 % \changes{v2.0.1}{2023/03/31}{插图、表格和算法等索引不缩进。}
+% \changes{v2.0.1}{2023/03/31}{调整插图、表格和算法等索引编号宽度。}
 % 图表清单标题前添加名称。
 %    \begin{macrocode}
 \cs_new_protected:Nn \@@_update_cft_presnum:
   {
     \tl_set:Nn \cftfigpresnum { \figurename \c_space_tl }
     \dim_zero:N \cftfigindent
+%<article>    \dim_set:Nn \cftfignumwidth { 1.8 em }
+%<!article>    \dim_set:Nn \cftfignumwidth { 2.8 em }
     \@@_dim_add_to_wd:Nn \cftfignumwidth { \cftfigpresnum }
     \tl_set:Nn \cfttabpresnum { \tablename  \c_space_tl }
     \dim_zero:N \cfttabindent
+%<article>    \dim_set:Nn \cfttabnumwidth { 1.8 em }
+%<!article>    \dim_set:Nn \cfttabnumwidth { 2.8 em }
     \@@_dim_add_to_wd:Nn \cfttabnumwidth { \cfttabpresnum }
   }
 \ctex_at_end_preamble:n
@@ -5157,7 +5161,8 @@
     \exp_args:Ne \newcounter { \tl_use:c { ext@ #3 } depth }
     \exp_args:Ne \setcounter { \tl_use:c { ext@ #3 } depth } { 1 }
     \dim_zero:c { cft #2 indent   }
-    \dim_set:cn { cft #2 numwidth } { 2.3 em }
+%<article>    \dim_set:cn { cft #2 numwidth } { 1.8 em }
+%<!article>    \dim_set:cn { cft #2 numwidth } { 2.8 em }
     \cs_set_eq:cc { l@ #3 } { l@ #2 }
     \@@_appto_cmd:Nn \@@_update_cft_presnum:
       {


### PR DESCRIPTION
* 取消索引条目的缩进；
* 调整索引编号宽度，`thesis` 和 `report` 分章编号的加长编号宽度 2.3em -> 2.8em，`article` 默认不分节编号的减小宽度 2.3em -> 1.8em。

| **Before** | **After**  | 
|--|--|
|<img src="https://user-images.githubusercontent.com/15205102/228991462-9cdc7b3d-72a0-44cc-b732-47ec434e09f7.svg" alt="before" width=200>|<img src="https://user-images.githubusercontent.com/15205102/228991472-8e8ae51e-056c-43a0-af5f-0a7bee301305.svg" alt="after" width=200>|
