### PR TITLE
fix: adjust the timing of defining theorems

### DIFF
--- a/sjtutex/source/sjtutex.dtx
+++ b/sjtutex/source/sjtutex.dtx
@@ -5744,8 +5744,6 @@
       { \popQED \endtrivlist \@endpefalse }
     \newtheoremstyle { sjtu }
       { } { } { \normalfont } { } { \bfseries \CJKsffamily } { } { \ccwd } { }
-    \theoremstyle { sjtu }
-    \@@_new_theorems:
   }
 %    \end{macrocode}
 %
@@ -5761,7 +5759,23 @@
     \qedsymbol     { \ensuremath { \QED } }
     \newtheorem* { proof } { \proofname }
     \theoremsymbol { }
-    \@@_new_theorems:
+  }
+%    \end{macrocode}
+%
+% 如果 \pkg{amsthm} 宏包或 \pkg{ntheorem} 宏包被加载，则定义定理环境。
+%    \begin{macrocode}
+\ctex_at_end_preamble:n
+  {
+    \@ifpackageloaded { amsthm }
+      { 
+        \theoremstyle { sjtu }
+        \@@_new_theorems: 
+      }
+      {
+        \@ifpackageloaded { ntheorem }
+          { \@@_new_theorems: }
+          {}
+      }
   }
 %    \end{macrocode}
 %


### PR DESCRIPTION
将定义定理环境的位置从 `amsthm`/`ntheorem` 宏包结束调整到导言区结束，理由如下：
1. 解决 https://github.com/sjtug/SJTUTeX/issues/57 中的问题；
2. 如果使用 `cleveref` 宏包，应在加载 `cleveref` 之后才定义定理环境（见 `texdoc cleveref` 第25页第2条）。