### PR TITLE
feat: add cref support for Chinese and Japanese

### DIFF
--- a/sjtutex/source/sjtutex.dtx
+++ b/sjtutex/source/sjtutex.dtx
@@ -2200,7 +2200,7 @@
 \cs_generate_variant:Nn \cs_gset:Npn { cpo }
 \cs_generate_variant:Nn \tl_const:Nn { Nv }
 \cs_generate_variant:Nn \clist_use:Nn { NV, cv }
-\exp_args_generate:n { Nnv }
+\exp_args_generate:n { Nnv, nvv }
 \cs_generate_variant:Nn \exp_last_unbraced:Ne { ce }
 \prg_generate_conditional_variant:Nnn \regex_match:nn { ne } { T, TF }
 %    \end{macrocode}
@@ -5980,6 +5980,35 @@
 %
 %    \begin{macrocode}
 %</class>
+%    \end{macrocode}
+%
+% \subsubsection{\pkg{cleveref} 宏包}
+%
+%    \begin{macrocode}
+%<*scheme>
+%<*zh|ja>
+\ctex_at_end_package:nn { cleveref }
+  {
+    \clist_map_inline:nn
+      {
+        assumption, axiom, conjecture, corollary, definition, example,
+        exercise, lemma, problem, proposition, theorem
+      }
+      {
+        \exp_args:Nnvv  \crefname {#1} { c__sjtu_name_ #1 _tl } { c__sjtu_name_ #1 _tl }
+        \exp_args:Nnvv  \Crefname {#1} { c__sjtu_name_ #1 _tl } { c__sjtu_name_ #1 _tl }
+      }
+    \crefname{figure}{\figurename}{\figurename}
+    \crefname{table}{\tablename}{\tablename}
+    \crefname{appendix}{\appendixname}{\appendixname}
+    \crefname{chapter}{\chaptername}{\chaptername}
+  }
+%</zh|ja>
+%<*zh>
+%</zh>
+%<*ja>
+%</ja>
+%</scheme>
 %    \end{macrocode}
 %
 % \subsection{名称配置}

--- a/sjtutex/source/sjtutex.dtx
+++ b/sjtutex/source/sjtutex.dtx
@@ -5984,30 +5984,117 @@
 %
 % \subsubsection{\pkg{cleveref} 宏包}
 %
+% 为 \pkg{cleveref} 宏包添加中文和日文支持。
+% 其中定理环境和一些已定义好的名称可共用代码。
 %    \begin{macrocode}
 %<*scheme>
-%<*zh|ja>
 \ctex_at_end_package:nn { cleveref }
   {
+%<*zh|ja>
     \clist_map_inline:nn
       {
         assumption, axiom, conjecture, corollary, definition, example,
         exercise, lemma, problem, proposition, theorem
       }
       {
-        \exp_args:Nnvv  \crefname {#1} { c__sjtu_name_ #1 _tl } { c__sjtu_name_ #1 _tl }
-        \exp_args:Nnvv  \Crefname {#1} { c__sjtu_name_ #1 _tl } { c__sjtu_name_ #1 _tl }
+        \exp_args:Nnvv
+          \crefname { #1 }  { c__sjtu_name_ #1 _tl }  { c__sjtu_name_ #1 _tl }
+        \exp_args:Nnvv
+          \Crefname { #1 }  { c__sjtu_name_ #1 _tl }  { c__sjtu_name_ #1 _tl }
       }
-    \crefname{figure}{\figurename}{\figurename}
-    \crefname{table}{\tablename}{\tablename}
-    \crefname{appendix}{\appendixname}{\appendixname}
-    \crefname{chapter}{\chaptername}{\chaptername}
-  }
+    \crefname { chapter   } { \chaptername        } { \chaptername        }
+    \crefname { appendix  } { \appendixname       } { \appendixname       }
+    \crefname { figure    } { \figurename         } { \figurename         }
+    \crefname { table     } { \tablename          } { \tablename          }
+    \crefname { algorithm } { \SJTU@algorithmname } { \SJTU@algorithmname }
 %</zh|ja>
 %<*zh>
+    \crefname { equation }  { 式 }  { 式 }
+
+    \crefformat { chapter       } { 第#2#1#3章  }
+    \crefformat { section       } { 第#2#1#3节  }
+    \crefformat { subsection    } { 第#2#1#3节  }
+    \crefformat { subsubsection } { 第#2#1#3节  }
+
+    \crefrangeformat  { chapter       } { 第#3#1#4章至第#5#2#6章  }
+    \crefrangeformat  { section       } { 第#3#1#4节至第#5#2#6节  }
+    \crefrangeformat  { subsection    } { 第#3#1#4节至第#5#2#6节  }
+    \crefrangeformat  { subsubsection } { 第#3#1#4节至第#5#2#6节  }
+
+    \crefmultiformat  { chapter }
+      { 第#2#1#3章 }  { 和第#2#1#3章 }  { ，第#2#1#3章 }  { 和第#2#1#3章 }
+    \crefmultiformat  { section }
+      { 第#2#1#3节 }  { 和第#2#1#3节 }  { ，第#2#1#3节 }  { 和第#2#1#3节 }
+    \crefmultiformat  { subsection }
+      { 第#2#1#3节 }  { 和第#2#1#3节 }  { ，第#2#1#3节 }  { 和第#2#1#3节 }
+    \crefmultiformat  { subsubsection }
+      { 第#2#1#3节 }  { 和第#2#1#3节 }  { ，第#2#1#3节 }  { 和第#2#1#3节 }
+
+    \crefrangemultiformat { chapter }
+      { 第#3#1#4章至第#5#2#6章    }  { 和第#3#1#4章至第#5#2#6章 }  
+      { ，第#3#1#4章至第#5#2#6章  }  { 和第#3#1#4章至第#5#2#6章 }
+    \crefrangemultiformat { section }
+      { 第#3#1#4节至第#5#2#6节    }  { 和第#3#1#4节至第#5#2#6节 }  
+      { ，第#3#1#4节至第#5#2#6节  }  { 和第#3#1#4节至第#5#2#6节 }
+    \crefrangemultiformat { subsection }
+      { 第#3#1#4节至第#5#2#6节    }  { 和第#3#1#4节至第#5#2#6节 }
+      { ，第#3#1#4节至第#5#2#6节  }  { 和第#3#1#4节至第#5#2#6节 }
+    \crefrangemultiformat { subsubsection }
+      { 第#3#1#4节至第#5#2#6节    }  { 和第#3#1#4节至第#5#2#6节 }
+      { ，第#3#1#4节至第#5#2#6节  }  { 和第#3#1#4节至第#5#2#6节 }
+
+    \NewDocumentCommand { \crefpairconjunction        } { } { ~和~  }
+    \NewDocumentCommand { \crefmiddleconjunction      } { } { ,     }
+    \NewDocumentCommand { \creflastconjunction        } { } { ~和~  }
+    \NewDocumentCommand { \crefpairgroupconjunction   } { } { ~和~  }
+    \NewDocumentCommand { \crefmiddlegroupconjunction } { } { ,     }
+    \NewDocumentCommand { \creflastgroupconjunction   } { } { ~和~  }
+    \NewDocumentCommand { \crefrangeconjunction       } { } { ~至~  }
 %</zh>
 %<*ja>
+    \crefname { equation }  { 式 }  { 式 }
+
+    \crefformat { chapter       } { 第#2#1#3章  }
+    \crefformat { section       } { 第#2#1#3節  }
+    \crefformat { subsection    } { 第#2#1#3節  }
+    \crefformat { subsubsection } { 第#2#1#3節  }
+
+    \crefrangeformat  { chapter       } { 第#3#1#4章から第#5#2#6章  }
+    \crefrangeformat  { section       } { 第#3#1#4節から第#5#2#6節  }
+    \crefrangeformat  { subsection    } { 第#3#1#4節から第#5#2#6節  }
+    \crefrangeformat  { subsubsection } { 第#3#1#4節から第#5#2#6節  }
+
+    \crefmultiformat  { chapter }
+      { 第#2#1#3章 }  { と第#2#1#3章 }  { ，第#2#1#3章 }  { と第#2#1#3章 }
+    \crefmultiformat  { section }
+      { 第#2#1#3節 }  { と第#2#1#3節 }  { ，第#2#1#3節 }  { と第#2#1#3節 }
+    \crefmultiformat  { subsection }
+      { 第#2#1#3節 }  { と第#2#1#3節 }  { ，第#2#1#3節 }  { と第#2#1#3節 }
+    \crefmultiformat  { subsubsection }
+      { 第#2#1#3節 }  { と第#2#1#3節 }  { ，第#2#1#3節 }  { と第#2#1#3節 }
+
+    \crefrangemultiformat { chapter }
+      { 第#3#1#4章から第#5#2#6章    }  { と第#3#1#4章から第#5#2#6章 }
+      { ，第#3#1#4章から第#5#2#6章  }  { と第#3#1#4章から第#5#2#6章 }
+    \crefrangemultiformat { section }
+      { 第#3#1#4節から第#5#2#6節    }  { と第#3#1#4節から第#5#2#6節 }
+      { ，第#3#1#4節から第#5#2#6節  }  { と第#3#1#4節から第#5#2#6節 }
+    \crefrangemultiformat { subsection }
+      { 第#3#1#4節から第#5#2#6節    }  { と第#3#1#4節から第#5#2#6節 }
+      { ，第#3#1#4節から第#5#2#6節  }  { と第#3#1#4節から第#5#2#6節 }
+    \crefrangemultiformat { subsubsection }
+      { 第#3#1#4節から第#5#2#6節    }  { と第#3#1#4節から第#5#2#6節 }
+      { ，第#3#1#4節から第#5#2#6節  }  { と第#3#1#4節から第#5#2#6節 }
+
+    \NewDocumentCommand { \crefpairconjunction        } { } { ~と~  }
+    \NewDocumentCommand { \crefmiddleconjunction      } { } { ,     }
+    \NewDocumentCommand { \creflastconjunction        } { } { ~と~  }
+    \NewDocumentCommand { \crefpairgroupconjunction   } { } { ~と~  }
+    \NewDocumentCommand { \crefmiddlegroupconjunction } { } { ,     }
+    \NewDocumentCommand { \creflastgroupconjunction   } { } { ~と~  }
+    \NewDocumentCommand { \crefrangeconjunction       } { } { ~から~  }
 %</ja>
+  }
 %</scheme>
 %    \end{macrocode}
 %


### PR DESCRIPTION
增加中文和日文的 `cleveref` 宏包支持。

写这些主要是自己将来需要，另一方面也就是练练手，可以酌情考虑要不要 merge 到项目里，如果没必要或者太麻烦就算了。

我写了一个简单的文档用来测试，没有动原本的测试文件：
```tex
\documentclass[lang=ja]{sjtuthesis}

\usepackage{amsthm}
\usepackage{hyperref}
\usepackage{cleveref}


\begin{document}

\mainmatter
\chapter{Test}\label{chap1}


%%% TESTS START %%%
\cref{sec1}

\cref{sec1,sec2,sec3}

\cref{sec1,sec2,sec3,sec5}

\cref{sec1,sec2,sec3,sec5,sec6,sec7}

\cref{fig1,fig2,fig3}

\cref{fig1,fig2,tab1,tab3}

\cref{fig1,fig2,tab1,tab3,tab2}

\cref{thm1,prop1,axm1}
%%% TESTS END %%%


\section{Test}\label{sec1}
\section{Test}\label{sec2}
\section{Test}\label{sec3}
\section{Test}\label{sec4}
\section{Test}\label{sec5}
\section{Test}\label{sec6}
\section{Test}\label{sec7}

\begin{theorem}\label{thm1}
    Test
\end{theorem}

\begin{proposition}\label{prop1}
    Test
\end{proposition}

\begin{axiom}\label{axm1}
    Test
\end{axiom}

\begin{figure}[p]
    \caption{}\label{fig1}
\end{figure}

\begin{figure}[p]
    \caption{}\label{fig2}
\end{figure}

\begin{figure}[p]
    \caption{}\label{fig3}
\end{figure}

\begin{table}[p]
    \caption{}\label{tab1}
\end{table}

\begin{table}[p]
    \caption{}\label{tab2}
\end{table}

\begin{table}[p]
    \caption{}\label{tab3}
\end{table}


\end{document}
```

测试结果如图所示：

![image](https://github.com/sjtug/SJTUTeX/assets/34743600/c0c3941e-94d5-4def-a501-4d46655e4d98)

![image](https://github.com/sjtug/SJTUTeX/assets/34743600/fb9f2aa2-5090-4ac8-a814-2573916a02ee)
