### PR TITLE
fix: period that is not full stop.

### DIFF
--- a/sjtutex/source/sjtutex.dtx
+++ b/sjtutex/source/sjtutex.dtx
@@ -6044,7 +6044,7 @@
     { address          } { Shanghai,~ P.R.~ China           } ,
     { author           } { Author                           } ,
     { supervisor       } { Supervisor                       } ,
-    { assoc_supervisor } { Assoc.~ Supervisor               } ,
+    { assoc_supervisor } { Assoc.\ Supervisor               } ,
     { co_supervisor    } { Co-supervisor                    } ,
     { title_page       } { Title~ Page                      } ,
     { declaration      } { Statutory~ Declaration           } ,


### PR DESCRIPTION
句点如果不是句子的结尾，其后的空格应使用 `\ `，来获得正确的 inter-word spacing，而不是 inter-sentence spacing，见 The TeXBook 第 73 页。

因此，将副导师的英文名称从 `Assoc.~ Supervisor` 改为 `Assoc.\ Supervisor`。

类似的 `Shanghai,~ P.R.~ China` 则不受影响，因为句点前是大写字母，TeX 会认为其不是句子结尾。

修改前：
![image](https://github.com/sjtug/SJTUTeX/assets/34743600/e7996289-9f0d-4e05-b874-2a264353ad8b)
修改后：
![image](https://github.com/sjtug/SJTUTeX/assets/34743600/b6aa061f-4aba-4697-a511-8144edf1bb0d)

MWE：
```latex
\documentclass{sjtuthesis}
\sjtusetup{
  info = {
    zh / supervisor      = {高德纳},
    en / supervisor      = {Donald Knuth},
    zh / assoc-supervisor  = {高德纳},
    en / assoc-supervisor  = {Donald Knuth},
  }
}
\begin{document}
\maketitle
\end{document}
```

[SJTUThesis 示例模板](https://github.com/sjtug/SJTUThesis) 中存在类似的问题（`setup.tex` 中的 `Prof. Mo Mo`），如果这样没问题的话，我稍后也在 v2-dev 分支上提一下 PR