### PR TITLE
fix: correct a minor error in the doc on name/abstract

### DIFF
--- a/sjtutex/source/sjtutex.dtx
+++ b/sjtutex/source/sjtutex.dtx
@@ -1296,7 +1296,7 @@
 %     |listtable|          & 表格                   & List of Tables                & Tabellenverzeichnis    & 表目次               \\
 %     |figure|             & 图                     & Figure                        & Abbildung              & 図                   \\
 %     |table|              & 表                     & Table                         & Tabelle                & 表                   \\
-%     |abstract| \rexpstar & 摘要                   & Abstract                      & Zusammenfassung        & 概要                 \\
+%     |abstract| \expstar & 摘要                   & Abstract                      & Zusammenfassung        & 概要                 \\
 %     |index|              & 索引                   & Index                         & Index                  & 索引                 \\
 %     |appendix|           & 附录                   & Appendix                      & Anhang                 & 付録                 \\
 %     |proof|              & 证明                   & Proof                         & Beweis                 & 证明                 \\


### PR DESCRIPTION
更正文档里一个小错误，name/abstract 应该是 sjtuarticle/sjtureport 独有的 key