### PR TITLE
refactor: simplify subject initial definitions

### DIFF
--- a/sjtutex/source/sjtutex.dtx
+++ b/sjtutex/source/sjtutex.dtx
@@ -4209,27 +4209,27 @@
 %<de>\keys_define:nn { sjtu / info / de }
 %<ja>\keys_define:nn { sjtu / info / ja }
   {
-    subject          .initial:e =
+    subject          .initial:n =
       {
 %<*zh>
-        \exp_not:V \c_@@_name_univ_zh_tl
-        \exp_not:V \c_@@_name_degree_level_zh_tl
-        \exp_not:V \c_@@_name_thesis_zh_tl
+        \c_@@_name_univ_zh_tl
+        \c_@@_name_degree_level_zh_tl
+        \c_@@_name_thesis_zh_tl
 %</zh>
 %<*en>
-        A~ Dissertation~ Submitted~ to \exp_not:N \\
-        { \exp_not:V \c_@@_name_univ_en_tl }~ for~
-        the~ Degree~ of~ { \exp_not:V \c_@@_name_degree_level_en_tl }
+        A~ Dissertation~ Submitted~ to \\
+        { \c_@@_name_univ_en_tl }~ for~
+        the~ Degree~ of~ { \c_@@_name_degree_level_en_tl }
 %</en>
 %<*de>
-        Eine~ Dissertation~ Eingereicht~ an \exp_not:N \\
-        der~ { \exp_not:V \c_@@_name_univ_de_tl }~ für~
-        { \exp_not:V \c_@@_name_degree_level_de_tl } titel
+        Eine~ Dissertation~ Eingereicht~ an \\
+        der~ { \c_@@_name_univ_de_tl }~ für~
+        { \c_@@_name_degree_level_de_tl } titel
 %</de>
 %<*ja>
-        \exp_not:V \c_@@_name_univ_ja_tl
-        \exp_not:V \c_@@_name_degree_level_ja_tl
-        \exp_not:V \c_@@_name_thesis_ja_tl
+        \c_@@_name_univ_ja_tl
+        \c_@@_name_degree_level_ja_tl
+        \c_@@_name_thesis_ja_tl
 %</ja>
       }
   }


### PR DESCRIPTION
 - `subject` 初始化时不再完全展开，避免使用 pdfTeX 时德语模板标题页生成错误的问题。