### PR TITLE
fix: resolve font issue in float environment for cases (https://github.com/sjtug/SJTUThesis/issues/1130)

### DIFF
--- a/sjtutex/CHANGELOG.md
+++ b/sjtutex/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- 修复浮动体环境中 `cases` 环境中的字体问题，在浮动体中将 `\SJTU@style@equation@font` 置空。
+
 ## [v2.2.1] - 2025-03-28
 
 ### Added

--- a/sjtutex/source/sjtutex.dtx
+++ b/sjtutex/source/sjtutex.dtx
@@ -3675,6 +3675,7 @@
   {
     \SJTU@style@float@font
 %    \end{macrocode}
+% \changes{unreleased}{2026/01/03}{修复浮动体中 \env{cases} 环境中的字体问题。}
 % 为修复浮动体环境中 cases 环境中的字体问题（见
 % \href{https://github.com/sjtug/SJTUThesis/issues/1130}{SJTUThesis Issue 1130}），
 % 在浮动体中将 \cs{SJTU@style@equation@font} 置空。

--- a/sjtutex/source/sjtutex.dtx
+++ b/sjtutex/source/sjtutex.dtx
@@ -3671,11 +3671,11 @@
 %<!thesis>    float-font .initial:n = \zihao { 5 }
   }
 \ctex_patch_cmd:Nnn \@floatboxreset
-  { \normalsize } 
+  { \normalsize }
   {
     \SJTU@style@float@font
 %    \end{macrocode}
-% 为修复浮动体环境中 cases 环境中的字体问题（见 
+% 为修复浮动体环境中 cases 环境中的字体问题（见
 % \href{https://github.com/sjtug/SJTUThesis/issues/1130}{SJTUThesis Issue 1130}
 % ），在浮动体中将 \cs{SJTU@style@equation@font} 置空。
 %    \begin{macrocode}

--- a/sjtutex/source/sjtutex.dtx
+++ b/sjtutex/source/sjtutex.dtx
@@ -3661,6 +3661,7 @@
 \tl_set:Nn \floatpagefraction { 0.60 }
 %    \end{macrocode}
 %
+% \changes{unreleased}{2026/01/03}{修复浮动体中 \env{cases} 环境中的字体问题。}
 % \begin{macro}{style/float-font}
 % 设置浮动体内的字体。
 %    \begin{macrocode}
@@ -3675,7 +3676,6 @@
   {
     \SJTU@style@float@font
 %    \end{macrocode}
-% \changes{unreleased}{2026/01/03}{修复浮动体中 \env{cases} 环境中的字体问题。}
 % 为修复浮动体环境中 \env{cases} 环境中的字体问题（见
 % \href{https://github.com/sjtug/SJTUThesis/issues/1130}{SJTUThesis Issue 1130}），
 % 在浮动体中将 \cs{SJTU@style@equation@font} 置空。

--- a/sjtutex/source/sjtutex.dtx
+++ b/sjtutex/source/sjtutex.dtx
@@ -3676,8 +3676,8 @@
     \SJTU@style@float@font
 %    \end{macrocode}
 % 为修复浮动体环境中 cases 环境中的字体问题（见
-% \href{https://github.com/sjtug/SJTUThesis/issues/1130}{SJTUThesis Issue 1130}
-% ），在浮动体中将 \cs{SJTU@style@equation@font} 置空。
+% \href{https://github.com/sjtug/SJTUThesis/issues/1130}{SJTUThesis Issue 1130}），
+% 在浮动体中将 \cs{SJTU@style@equation@font} 置空。
 %    \begin{macrocode}
     \RenewDocumentCommand { \SJTU@style@equation@font } { } { }
   }

--- a/sjtutex/source/sjtutex.dtx
+++ b/sjtutex/source/sjtutex.dtx
@@ -3671,7 +3671,16 @@
 %<!thesis>    float-font .initial:n = \zihao { 5 }
   }
 \ctex_patch_cmd:Nnn \@floatboxreset
-  { \normalsize } { \SJTU@style@float@font }
+  { \normalsize } 
+  {
+    \SJTU@style@float@font
+%    \end{macrocode}
+% 为修复浮动体环境中 cases 环境中的字体问题（见 
+% \href{https://github.com/sjtug/SJTUThesis/issues/1130}{SJTUThesis Issue 1130}
+% ），在浮动体中将 \cs{SJTU@style@equation@font} 置空。
+%    \begin{macrocode}
+    \RenewDocumentCommand { \SJTU@style@equation@font } { } { }
+  }
 %    \end{macrocode}
 % \end{macro}
 %

--- a/sjtutex/source/sjtutex.dtx
+++ b/sjtutex/source/sjtutex.dtx
@@ -3679,7 +3679,7 @@
 % \href{https://github.com/sjtug/SJTUThesis/issues/1130}{SJTUThesis Issue 1130}），
 % 在浮动体中将 \cs{SJTU@style@equation@font} 置空。
 %    \begin{macrocode}
-    \RenewDocumentCommand { \SJTU@style@equation@font } { } { }
+    \let \SJTU@style@equation@font \@empty
   }
 %    \end{macrocode}
 % \end{macro}

--- a/sjtutex/source/sjtutex.dtx
+++ b/sjtutex/source/sjtutex.dtx
@@ -3676,7 +3676,7 @@
     \SJTU@style@float@font
 %    \end{macrocode}
 % \changes{unreleased}{2026/01/03}{修复浮动体中 \env{cases} 环境中的字体问题。}
-% 为修复浮动体环境中 cases 环境中的字体问题（见
+% 为修复浮动体环境中 \env{cases} 环境中的字体问题（见
 % \href{https://github.com/sjtug/SJTUThesis/issues/1130}{SJTUThesis Issue 1130}），
 % 在浮动体中将 \cs{SJTU@style@equation@font} 置空。
 %    \begin{macrocode}


### PR DESCRIPTION
解决 https://github.com/sjtug/SJTUThesis/issues/1130

按照之前的讨论，在浮动体中把 `\SJTU@style@equation@font` 置空